### PR TITLE
Enable alwaysShow() option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,3 +47,16 @@ You can also pass in an array of options to use with Trumbowyg
         ];
     }
 ```
+
+By default, the Trumbowyg field will not display their content when viewing a resource on its detail page. It will be hidden behind a "Show Content" link, that when clicked will reveal the content. You may specify the Trumbowyg field should always display its content by calling the alwaysShow method on the field itself
+
+```
+    public function fields(Request $request)
+    {
+        return [
+            ...,
+            NovaTrumbowyg::make('body')->alwaysShow(),
+            ...
+        ];
+    }
+```

--- a/src/NovaTrumbowyg.php
+++ b/src/NovaTrumbowyg.php
@@ -2,10 +2,13 @@
 
 namespace Johnathan\NovaTrumbowyg;
 
+use Laravel\Nova\Fields\Expandable;
 use Laravel\Nova\Fields\Field;
 
 class NovaTrumbowyg extends Field
 {
+    use Expandable;
+
     /**
      * The field's component.
      *
@@ -16,5 +19,17 @@ class NovaTrumbowyg extends Field
     public function options(array $options = [])
     {
         return $this->withMeta(['options' => $options]);
+    }
+    
+    /**
+     * Prepare the element for JSON serialization.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return array_merge(parent::jsonSerialize(), [
+            'shouldShow' => $this->shouldBeExpanded(),
+        ]);
     }
 }


### PR DESCRIPTION
Use the`Laravel\Nova\Fields\Expandable` Trait to enable the `alwaysShow()` option, the default in Trait `Laravel\Nova\Fields\Expandable` is set to `false`