### PR TITLE
make jsonSerialize function compatible with nova 4.33.2

### DIFF
--- a/src/NovaTrumbowyg.php
+++ b/src/NovaTrumbowyg.php
@@ -45,7 +45,7 @@ class NovaTrumbowyg extends Field
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_merge(parent::jsonSerialize(), [
             'shouldShow' => $this->shouldBeExpanded(),


### PR DESCRIPTION
fix :
Declaration of Johnathan\\NovaTrumbowyg\\NovaTrumbowyg::jsonSerialize() must be compatible with Laravel\\Nova\\Fields\\Field::jsonSerialize(): array